### PR TITLE
refactor: use regex in test helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -273,6 +282,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
+name = "memchr"
+version = "2.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
 name = "miette"
 version = "7.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -317,6 +332,35 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "regex"
+version = "1.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "ropey"
@@ -398,8 +442,10 @@ name = "syncdoc-core"
 version = "0.1.5"
 dependencies = [
  "insta",
+ "once_cell",
  "proc-macro2",
  "quote",
+ "regex",
  "ropey",
  "rust-format",
  "tempfile",

--- a/syncdoc-core/Cargo.toml
+++ b/syncdoc-core/Cargo.toml
@@ -23,5 +23,7 @@ unsynn.workspace = true
 
 [dev-dependencies]
 insta.workspace = true
+once_cell = "1.21.3"
+regex = "1.12.2"
 rust-format.workspace = true
 tempfile.workspace = true

--- a/syncdoc-core/tests/helpers/formatting.rs
+++ b/syncdoc-core/tests/helpers/formatting.rs
@@ -1,115 +1,68 @@
+use once_cell::sync::Lazy;
+use regex::Regex;
 use std::collections::{HashMap, HashSet};
 use std::process::Command;
+
+static IMPL_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"impl(?:<[^>]+>)?\s+(?:(\w+)\s+for\s+)?(\w+)").unwrap());
 
 pub fn create_dummy_types_str(code: &str, existing_types: &HashSet<String>) -> String {
     let mut types_to_define = Vec::new();
     let mut trait_methods: HashMap<String, Vec<String>> = HashMap::new();
 
-    for line in code.lines() {
-        let trimmed = line.trim();
+    for cap in IMPL_RE.captures_iter(code) {
+        let trait_name = cap.get(1).map(|m| m.as_str());
+        let type_name = cap.get(2).map(|m| m.as_str()).unwrap_or("");
 
-        if trimmed.starts_with("impl ") || trimmed.starts_with("impl<") {
-            let impl_part = trimmed.split('{').next().unwrap_or("");
+        // Handle trait name
+        if let Some(trait_name) = trait_name {
+            if !trait_name.is_empty()
+                && trait_name.chars().next().unwrap().is_uppercase()
+                && !existing_types.contains(trait_name)
+            {
+                trait_methods
+                    .entry(trait_name.to_string())
+                    .or_insert_with(Vec::new);
+            }
+        }
 
-            if let Some(for_pos) = impl_part.find(" for ") {
-                // "impl Trait for Type"
-                let trait_part = impl_part[4..for_pos].trim();
-                let type_part = impl_part[for_pos + 5..].trim();
-
-                // Extract trait name
-                let trait_name = trait_part
-                    .split_whitespace()
-                    .filter(|s| *s != "unsafe")
-                    .last()
-                    .unwrap_or("")
-                    .split('<')
-                    .next()
-                    .unwrap_or("")
-                    .trim();
-
-                if !trait_name.is_empty()
-                    && trait_name.chars().next().unwrap().is_uppercase()
-                    && !existing_types.contains(trait_name)
-                {
-                    trait_methods
-                        .entry(trait_name.to_string())
-                        .or_insert_with(Vec::new);
-                }
-
-                // Extract type name
-                let type_name = type_part
-                    .split_whitespace()
-                    .next()
-                    .unwrap_or("")
-                    .split('<')
-                    .next()
-                    .unwrap_or("")
-                    .trim();
-
-                if !type_name.is_empty()
-                    && type_name.chars().next().unwrap().is_uppercase()
-                    && !existing_types.contains(type_name)
-                {
-                    types_to_define.push(format!("pub struct {};", type_name));
-                }
-            } else {
-                // "impl Type" or "impl<T> Type"
-                let parts: Vec<&str> = impl_part.split_whitespace().collect();
-                if let Some(last) = parts.last() {
-                    let type_name = last.split('<').next().unwrap_or(last).trim();
-
-                    if !type_name.is_empty()
-                        && type_name
-                            .chars()
-                            .next()
-                            .map(|c| c.is_uppercase())
-                            .unwrap_or(false)
-                        && !existing_types.contains(type_name)
-                    {
-                        let has_generics = last.contains('<') && last.contains('>');
-
-                        let def = if has_generics {
-                            format!(
-                                "pub struct {}<T> {{ _inner: std::marker::PhantomData<T> }}",
-                                type_name
-                            )
-                        } else {
-                            format!("pub struct {};", type_name)
-                        };
-
-                        types_to_define.push(def);
-                    }
-                }
+        // Handle type name
+        if !type_name.is_empty()
+            && type_name.chars().next().unwrap().is_uppercase()
+            && !existing_types.contains(type_name)
+        {
+            // Check if generic (look at the original match context)
+            let match_start = cap.get(0).unwrap().start();
+            if let Some(line) = code[match_start..].lines().next() {
+                let has_generics = line.contains('<') && line.contains('>');
+                let def = if has_generics {
+                    format!(
+                        "pub struct {}<T> {{ _inner: std::marker::PhantomData<T> }}",
+                        type_name
+                    )
+                } else {
+                    format!("pub struct {};", type_name)
+                };
+                types_to_define.push(def);
             }
         }
     }
 
-    // Scan for methods inside trait impls to add to trait definitions
+    // Scan for methods inside trait impls
+    let lines: Vec<&str> = code.lines().collect();
     let mut in_trait_impl = false;
     let mut current_trait = String::new();
     let mut depth = 0;
 
-    for line in code.lines() {
+    for line in &lines {
         let trimmed = line.trim();
 
         if trimmed.starts_with("impl ") && trimmed.contains(" for ") {
-            if let Some(impl_part) = trimmed.split('{').next() {
-                if let Some(for_pos) = impl_part.find(" for ") {
-                    let trait_part = impl_part[4..for_pos].trim();
-                    let trait_name = trait_part
-                        .split_whitespace()
-                        .last()
-                        .unwrap_or("")
-                        .split('<')
-                        .next()
-                        .unwrap_or("")
-                        .trim();
-
-                    if !trait_name.is_empty() {
-                        current_trait = trait_name.to_string();
-                        in_trait_impl = true;
-                        depth = 0;
-                    }
+            if let Some(caps) = IMPL_RE.captures(trimmed) {
+                if let Some(trait_name) = caps.get(1) {
+                    current_trait = trait_name.as_str().to_string();
+                    in_trait_impl = true;
+                    depth = 0;
                 }
             }
         }
@@ -120,13 +73,10 @@ pub fn create_dummy_types_str(code: &str, existing_types: &HashSet<String>) -> S
 
             // Extract method signatures
             if trimmed.contains("fn ") && !current_trait.is_empty() {
-                if let Some(fn_pos) = trimmed.find("fn ") {
-                    let after_fn = &trimmed[fn_pos..];
-                    if let Some(body_start) = after_fn.find('{') {
-                        let sig = after_fn[..body_start].trim().to_string() + ";";
-                        if let Some(methods) = trait_methods.get_mut(&current_trait) {
-                            methods.push(sig);
-                        }
+                if let Some(body_start) = trimmed.find('{') {
+                    let sig = trimmed[..body_start].trim().to_string() + ";";
+                    if let Some(methods) = trait_methods.get_mut(&current_trait) {
+                        methods.push(sig);
                     }
                 }
             }
@@ -138,7 +88,7 @@ pub fn create_dummy_types_str(code: &str, existing_types: &HashSet<String>) -> S
         }
     }
 
-    // Generate trait definitions with methods
+    // Generate trait definitions
     for (trait_name, methods) in trait_methods {
         if methods.is_empty() {
             types_to_define.push(format!("pub trait {} {{}}", trait_name));
@@ -163,18 +113,18 @@ fn inject_types_recursive(code: &str, existing_types: &HashSet<String>) -> Strin
     let lines: Vec<&str> = code.lines().collect();
     let mut i = 0;
 
+    static MOD_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"(?:pub\s+)?mod\s+\w+\s*\{").unwrap());
+
     while i < lines.len() {
         let line = lines[i];
         let trimmed = line.trim();
 
         // Check if this line starts a module
-        if (trimmed.starts_with("mod ") || trimmed.starts_with("pub mod ")) && trimmed.contains('{')
-        {
+        if MOD_RE.is_match(trimmed) {
             let module_start = i;
             let mut depth = 1;
             let mut j = i + 1;
 
-            // Find the end of this module
             while j < lines.len() && depth > 0 {
                 let module_line = lines[j];
                 depth += module_line.matches('{').count();
@@ -183,35 +133,18 @@ fn inject_types_recursive(code: &str, existing_types: &HashSet<String>) -> Strin
             }
 
             let module_end = j - 1;
-
-            // Extract module content
             let module_content_lines = &lines[(module_start + 1)..module_end];
             let module_content = module_content_lines.join("\n");
 
-            // Find types needed in this module
+            // Find types needed
             let mut types_needed = Vec::new();
             for content_line in module_content_lines {
-                let trimmed_content = content_line.trim();
-                if trimmed_content.starts_with("impl ") || trimmed_content.starts_with("impl<") {
-                    let impl_part = trimmed_content.split('{').next().unwrap_or("");
-
-                    let type_name = if let Some(for_pos) = impl_part.find(" for ") {
-                        let type_part = impl_part[for_pos + 5..].trim();
-                        type_part
-                            .split_whitespace()
-                            .next()
-                            .unwrap_or("")
-                            .split('<')
-                            .next()
-                            .unwrap_or("")
-                            .trim()
-                    } else {
-                        let parts: Vec<&str> = impl_part.split_whitespace().collect();
-                        parts
-                            .last()
-                            .map(|s| s.split('<').next().unwrap_or(s).trim())
-                            .unwrap_or("")
-                    };
+                if let Some(caps) = IMPL_RE.captures(content_line.trim()) {
+                    let type_name = caps
+                        .get(1)
+                        .or(caps.get(2))
+                        .map(|m| m.as_str())
+                        .unwrap_or("");
 
                     if !type_name.is_empty()
                         && !existing_types.contains(type_name)
@@ -222,10 +155,8 @@ fn inject_types_recursive(code: &str, existing_types: &HashSet<String>) -> Strin
                 }
             }
 
-            // Recursively process module content
             let processed_content = inject_types_recursive(&module_content, existing_types);
 
-            // Write module with injected imports
             result.push_str(lines[module_start]);
             result.push('\n');
 


### PR DESCRIPTION
Helper code was +25% larger before this PR (refactor to use regex instead of string parsing)